### PR TITLE
Replace deprecated `scipy.odr` (to be removed in scipy 1.19) with `odrpack.odr_fit`

### DIFF
--- a/atomap/atom_finding_refining.py
+++ b/atomap/atom_finding_refining.py
@@ -606,7 +606,7 @@ def calculate_center_of_mass(arr):
     dy = np.sum(arr, -1)
     dx = np.sum(arr, -2)
 
-    (Y, X) = arr.shape[-2:]
+    Y, X = arr.shape[-2:]
     cx = np.sum(dx * np.arange(X), axis=-1).T
     cy = np.sum(dy * np.arange(Y), axis=-1).T
     return np.array([cy, cx]).T

--- a/atomap/atom_plane.py
+++ b/atomap/atom_plane.py
@@ -396,7 +396,7 @@ class Atom_Plane:
             y_pos = self.get_y_position_list()
             x0, x1 = min(x_pos), max(x_pos)
             new_x = np.linspace(x0, x1, 200)
-            new_y = linear_fit_func(beta, new_x)
+            new_y = linear_fit_func(new_x, beta)
             plt.ioff()
             fig = plt.figure()
             ax = fig.gca(projection=Axes3D.name)

--- a/atomap/fitting_tools.py
+++ b/atomap/fitting_tools.py
@@ -1,9 +1,9 @@
 from math import sqrt
 import numpy as np
-import scipy.odr
+import odrpack as odr
 
 
-def linear_fit_func(p, t):
+def linear_fit_func(t, p):
     return p[0] * t + p[1]
 
 
@@ -34,11 +34,8 @@ def ODR_linear_fitter(x, y):
     array([-1.,  1.])
 
     """
-    Model = scipy.odr.Model(linear_fit_func)
-    Data = scipy.odr.RealData(x, y)
-    Odr = scipy.odr.ODR(Data, Model, [10000, 1], maxit=10000)
-    output = Odr.run()
-    beta = output.beta
+    result = odr.odr_fit(linear_fit_func, x, y, [10000, 1], maxit=10000)
+    beta = result.beta
     return beta
 
 

--- a/atomap/main.py
+++ b/atomap/main.py
@@ -97,11 +97,9 @@ def make_atom_lattice_from_image(
     image0_scale = s_image0.axes_manager[0].scale
     if pixel_separation is None:
         if process_parameter.peak_separation is None:
-            raise ValueError(
-                "pixel_separation is not set.\
+            raise ValueError("pixel_separation is not set.\
                     Either set it in the process_parameter.peak_separation\
-                    or pixel_separation parameter"
-            )
+                    or pixel_separation parameter")
         else:
             pixel_separation = process_parameter.peak_separation / image0_scale
     initial_atom_position_list = get_atom_positions(

--- a/atomap/tests/test_fitting_tools.py
+++ b/atomap/tests/test_fitting_tools.py
@@ -22,7 +22,7 @@ class TestODRFitter:
         y = np.arange(0, 10, 1)
         x = np.full_like(y, 5)
         beta = ft.ODR_linear_fitter(x, y)
-        y_vector = [0, ft.linear_fit_func(beta, 5)]
+        y_vector = [0, ft.linear_fit_func(5, beta)]
         x_vector = [1, 0]
         dot = np.dot(x_vector, y_vector)
         assert dot == 0.0

--- a/atomap/tests/test_quantification.py
+++ b/atomap/tests/test_quantification.py
@@ -40,7 +40,7 @@ class TestDetectorNormalisation:
 
     def test_find_flux_limits_running(self):
         flux1 = quant.centered_distance_matrix((63, 63), np.zeros((128, 128)))
-        (profiler, flux_profile) = quant.find_flux_limits(100 - flux1, 25)
+        profiler, flux_profile = quant.find_flux_limits(100 - flux1, 25)
         assert len(flux_profile) == math.ceil((64**2 + 64**2) ** 0.5)
 
 

--- a/atomap/tools.py
+++ b/atomap/tools.py
@@ -17,7 +17,6 @@ import atomap.atom_position as ap
 from sklearn.cluster import DBSCAN
 import logging
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
   {name = "Magnus Nord", email = "magnunor@gmail.com"},
 ]
 dependencies = [
+    "odrpack",
     "scipy>=1.4.0",
     "numpy>=1.13",
     "h5py",


### PR DESCRIPTION
Fix for https://github.com/hyperspy/hyperspy-extensions-list/issues/104.